### PR TITLE
Allow build crate without regenerating proto stuff

### DIFF
--- a/rust_old/Cargo.lock
+++ b/rust_old/Cargo.lock
@@ -31,5 +31,6 @@ dependencies = [
 name = "rust"
 version = "0.1.0"
 dependencies = [
+ "protobuf",
  "protobuf-codegen-pure",
 ]

--- a/rust_old/Cargo.toml
+++ b/rust_old/Cargo.toml
@@ -5,7 +5,12 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["proto"]
+proto = []
+
 [build-dependencies]
 protobuf-codegen-pure = "2"
 
 [dependencies]
+protobuf = "2"

--- a/rust_old/build.rs
+++ b/rust_old/build.rs
@@ -1,5 +1,5 @@
-use std::{ io, path::Path, fs};
 use protobuf_codegen_pure::Customize;
+use std::{env, fs, io, path::Path};
 
 fn list_files(dir: &Path, path_vec: &mut Vec<String>) -> io::Result<()> {
     if dir.is_dir() {
@@ -18,6 +18,11 @@ fn list_files(dir: &Path, path_vec: &mut Vec<String>) -> io::Result<()> {
 }
 
 fn main() {
+    let should_generate = env::var_os("CARGO_FEATURE_PROTO").is_some();
+    if !should_generate {
+        return;
+    }
+
     for dir in fs::read_dir("../proto/chain/injective").unwrap() {
         let customizer = Customize {
             gen_mod_rs: Some(true),
@@ -34,12 +39,12 @@ fn main() {
         let _ = fs::create_dir(out_dir.clone());
 
         protobuf_codegen_pure::Codegen::new()
-        .out_dir(out_dir)
-        .inputs(sub_dirs)
-        .includes(["../proto/chain", "../proto/chain/injective"])
-        .customize(customizer)
-        .run()
-        .expect("Protobuf codegen failed");
+            .out_dir(out_dir)
+            .inputs(sub_dirs)
+            .includes(["../proto/chain", "../proto/chain/injective"])
+            .customize(customizer)
+            .run()
+            .expect("Protobuf codegen failed");
     }
 
     let customizer = Customize {
@@ -53,10 +58,10 @@ fn main() {
     let out_dir = String::from("src/indexer");
     let _ = fs::create_dir(out_dir.clone());
     protobuf_codegen_pure::Codegen::new()
-    .out_dir(out_dir)
-    .inputs(sub_dirs)
-    .includes(["../proto/indexer"])
-    .customize(customizer)
-    .run()
-    .expect("Protobuf codegen for indexer failed");
+        .out_dir(out_dir)
+        .inputs(sub_dirs)
+        .includes(["../proto/indexer"])
+        .customize(customizer)
+        .run()
+        .expect("Protobuf codegen for indexer failed");
 }

--- a/rust_old/src/lib.rs
+++ b/rust_old/src/lib.rs
@@ -1,0 +1,6 @@
+//! Injective Proto/gRPC
+
+pub mod indexer;
+// TODO: fix module generation code
+// #[path = "chain/injective/mod.rs"]
+// pub mod injective;


### PR DESCRIPTION
**Motivation**
This allows downstream crates to use the rust crate here.
this currently doesn't work as it requires the `build.rs` to run with .proto files which don't exist  for downstream clients (nor are they public afaict)
also there is no top level exports as the `lib.rs` is empty

```toml
injective-proto = { package = "rust", path = "https://github.com/InjectiveLabs/injective-proto.git" }
```

**Fix**
The protobuf regeneration is now behind a feature flag (on by default).
with this PR, downstream crates can use `default-features = false` to use the generated modules verbatim

```toml
injective-proto = { package = "rust", path = "https://github.com/InjectiveLabs/injective-proto.git", default-features = false }
```

note this allows indexer structs to be used but not injective/chain/* see #3 

